### PR TITLE
Vagrant: Install qemu-user package during provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure(2) do |config|
       sudo apt-get -y install g++-mips-linux-gnu gdb-multiarch
 
       # QEMU run-time emulator
-      sudo apt-get -y install qemu
+      sudo apt-get -y install qemu qemu-user
 
    SHELL
 end


### PR DESCRIPTION
It appears that `qemu-mips` is no longer available in the `mips` package after upgrading the version of
Ubuntu from Xenial to Focal.

## What does this PR do?

- [x] Installs the `qemu-user` package during Vagrant provisioning, such that the `qemu-mips` binary is available
